### PR TITLE
Change event to channel where event is not defined

### DIFF
--- a/public/app/views/docs/middleware-and-authorization.html
+++ b/public/app/views/docs/middleware-and-authorization.html
@@ -53,7 +53,7 @@ wsServer.addMiddleware(wsServer.MIDDLEWARE_HANDSHAKE,
     if (...) {
       next() // Allow
     } else {
-      next(socket.id + ' is not allowed to subscribe to event ' + event); // Block
+      next(socket.id + ' is not allowed to subscribe to channel ' + channel); // Block
     }
   }
 );</pre>
@@ -72,7 +72,7 @@ wsServer.addMiddleware(wsServer.MIDDLEWARE_HANDSHAKE,
     if (...) {
       next() // Allow
     } else {
-      next(socket.id + ' is not allowed to publish event ' + event); // Block
+      next(socket.id + ' is not allowed to publish channel ' + channel); // Block
     }
   }
 );</pre>


### PR DESCRIPTION
I tried to implement subscribe middlware in my app, but noticed event was not defined. It should reference channel I think.