### PR TITLE
Modify Getting Started page to reflect the SocketCluster boilerplate app

### DIFF
--- a/public/app/views/docs/getting-started.html
+++ b/public/app/views/docs/getting-started.html
@@ -56,9 +56,9 @@
         <p>
           To test SocketCluster's realtime features, you can open your browser's developer console and enter the following command:
         </p>
-        <pre class="prettyprint">socket.emit('ping', {message: 'This is an object with a message property'});</pre>
+        <pre class="prettyprint">socket.emit('sampleClientEvent', {message: 'This is an object with a message property'});</pre>
         <p>
-          You should get a 'pong' message back - The server receives your ping event and then publishes a pong event to all clients which are listening to it.
+          You should get a 'Sample channel message: 1' message back - The server receives your sampleClientEvent event and then publishes a sample event to all clients which are listening to it.
         </p>
         <p>
           You can pass almost anything as the second argument to the emit and publish command so long as it's compatible with JSON.


### PR DESCRIPTION
Running the following command does not return anything in the browser's developer console:
```
socket.emit('ping', {message: 'This is an object with a message property'});
```


The current SocketCluster boilerplate app `socketcluster create myApp` does not appear to have a 'ping' / 'pong' event.

This pull request is just to update the command and info to:
```
socket.emit('sampleClientEvent', {message: 'This is an object with a message property'});
```

> You should get a 'Sample channel message: 1' message back - The server receives your sampleClientEvent event and then publishes a sample event to all clients which are listening to it.

