### PR TITLE
Fixed the Channel link to show to '/docs/api-scchannel-server'

### DIFF
--- a/public/app/views/docs/api-global.html
+++ b/public/app/views/docs/api-global.html
@@ -62,14 +62,14 @@
             <td>subscribe(channelName)</td>
             <td>
               Subscribe this global nData client to the specified channel.
-              This function returns a <a href="/#!/docs/api-channel">Channel</a> object which lets you watch for incoming data on that channel.
+              This function returns a <a href="/#!/docs/api-scchannel-server">Channel</a> object which lets you watch for incoming data on that channel.
             </td>
           </tr>
           <tr>
             <td>unsubscribe(channelName, [callback])</td>
             <td>
               Unsubscribe this global nData client from the specified channel.
-              You can reactivate the <a href="/#!/docs/api-channel">Channel</a> object by calling subscribe(channelName) again at a later time.
+              You can reactivate the <a href="/#!/docs/api-scchannel-server">Channel</a> object by calling subscribe(channelName) again at a later time.
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
There is no '/docs/api-channel' so clicking this resulted in an empty page being loaded. Changed this to show to the backend channel documentation '/docs/api-scchannel-server'