### PR TITLE
feat(website): add DocSearch as recommended by docusaurus

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -21,6 +21,13 @@ const users = [
 ];
 
 const siteConfig = {
+  algolia: {
+    apiKey: 'ddd1c50927f4bfa6b4cdf793752ed63e',
+    indexName: 'socketcluster',
+    algoliaOptions: {
+      facetFilters: [ "version:VERSION" ]
+    }
+  },
   title: 'SocketCluster', // Title for your website.
   tagline: 'Highly scalable realtime framework optimized for async/await',
   url: 'https://socketcluster.io', // Your website URL


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.